### PR TITLE
Fix: use spaces for all indents a few more things

### DIFF
--- a/action_dispatcher.py
+++ b/action_dispatcher.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3 -u
+#!/usr/bin/env python
 import MDSplus
 import redis
 import threading
@@ -437,8 +437,8 @@ class ActionDispatcher:
                 for depNid in self.depAffected[treeShot][actionNid]:
                     if self.checkDispatch(tree, depNid):
                         ident = self.idents[treeShot][depNid]
-            		serverExists = self.serverExists(ident)
-			if serverExists:
+                        serverExists = self.serverExists(ident)
+                        if serverExists:
                             self.red.lpush('ACTION_SERVER_TODO:'+ident, 
                                 treeName+'+'+str(shot)+'+'+tree.getNode(depNid).getFullPath()+'+'+str(depNid)+'+'+str(self.timeouts[treeShot][depNid]))
                             print('Dispatching action '+tree.getNode(depNid).getFullPath()+'   Tree: '+tree.name+'  Shot: '+str(tree.shot))
@@ -552,7 +552,7 @@ class ActionDispatcher:
                             red.hset('ACTION_SERVER_ACTIVE:'+ident, str(id), 'OFF')  
                             if not (ident+':'+str(id)) in wasAlive.keys() or wasAlive[ident+':'+str(id)]:
                                 print('Watchdog Failed for server class'+ident+' id '+str(id)+': server not responding')
-                            	self.removeDeadPending(self.tree, ident, id)
+                                self.removeDeadPending(self.tree, ident, id)
                             wasAlive[ident+':'+str(id)] = False
                         else:
                             wasAlive[ident+':'+str(id)] = True

--- a/action_server.py
+++ b/action_server.py
@@ -193,7 +193,7 @@ def handleExecute(treeName, shot, actionPath, timeout, red, ident, serverId, act
             timeoutSecs = int(2*timeout)
         for i in range(timeoutSecs):
             t.join(0.5)
-            if not t.isAlive():
+            if not t.is_alive():
                 break
             else:
                 if red.hget('ABORT_REQUESTS:'+ident, actionPath) == b'1':

--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
   "author": "Gabriele Manduchi <gabriele.manduchi@igi.cnr.it>",
   "license": "MIT",
   "dependencies": {
-    "redis": "^4.1.0"
+    "redis": "^4.7.1"
   }
 }


### PR DESCRIPTION
changed all of the tab indents to space indents.

fixed problem (maybe caused by that change) with indents in
    actDisp.handleNotifications()

```
Exception in thread Thread-1 (manageNotifications):
Traceback (most recent call last):
  File "/usr/lib/python3.10/threading.py", line 1016, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.10/threading.py", line 953, in run
    self._target(*self._args, **self._kwargs)
  File "/home/jas/RedisActionDispatcher/action_dispatcher.py", line 599, in manageNotifications
    actDisp.handleNotifications()
  File "/home/jas/RedisActionDispatcher/action_dispatcher.py", line 441, in handleNotifications
```
Changed thread.isAlive() to thread.is_alive()

Not sure why I had to update the minimum redis version in package.json

Changed the `#!/usr/bin/python3` to `#!/usr/bin/env python` so that virtual environments work